### PR TITLE
This brach contains refactoring of the middlewares and file-generator…

### DIFF
--- a/src/assets/templates/stories.jst
+++ b/src/assets/templates/stories.jst
@@ -5,6 +5,6 @@ import { storiesOf } from '@storybook/react-native';
 import {{componentName}} from './{{componentPath}}.{{extension}}';
 
 storiesOf('{{storiesOf}}', module)
-  .add('{{componentName}}', screenSize => (
-    <{{componentName}} screenSize={screenSize} />
+  .add('{{componentName}}', () => (
+    <{{componentName}} />
   ));

--- a/src/file-generator/component.js
+++ b/src/file-generator/component.js
@@ -7,9 +7,10 @@ import { renderProps } from './styles';
 
 import toFile from './to-file';
 
-function collectImports({ importCode, children }) {
+function collectImports({ importDecorator, importComponent, children }) {
   return _.concat(
-    importCode || [],
+    importDecorator || [],
+    importComponent || [],
     _.flatMap(children || [], child => collectImports(child)),
   );
 }
@@ -38,12 +39,15 @@ export default function exportJSFile(
   const {
     componentName,
     componentPath,
-    renderCode,
+    renderDecorator,
+    renderComponent,
     children,
     props,
     hoc,
     svgCode,
   } = component;
+
+  const renderCode = renderDecorator || renderComponent;
 
   const exportPath = svgCode ? exportSvgPath : exportCodePath;
   const ext = svgCode ? fileExt : componentExt;

--- a/src/file-generator/index.js
+++ b/src/file-generator/index.js
@@ -36,8 +36,6 @@ export default async function exportTree({ context, sourceMap }) {
   Object.keys(sourceMap).forEach(key => {
     const node = sourceMap[key];
 
-    console.log(`\n### [${node.id}] '${node.name}' -> ${key}`);
-
     const extractStyles =
       ['in-component-file', 'in-styles-file'].indexOf(stylesMode) >= 0;
 
@@ -60,4 +58,11 @@ export default async function exportTree({ context, sourceMap }) {
       });
     }
   });
+
+  console.log('### Export Report ###');
+  Object.keys(sourceMap).forEach(key => {
+    const node = sourceMap[key];
+    console.log(`  [${node.id}] '${node.name}' -> ${key}`);
+  });
+  console.log('###');
 }

--- a/src/parser/middleware/react-native/background-image.js
+++ b/src/parser/middleware/react-native/background-image.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import axios from 'axios';
-import get from 'lodash/get';
+import _ from 'lodash';
 
 import {
   rip,
@@ -58,8 +58,11 @@ export default async function middleware({ node, nodeJson, context }) {
 
   return {
     ...node,
-    importCode: ["import { ImageBackground } from 'react-native';"],
-    renderCode: (props, children) => [
+    importComponent: _.concat(
+      ["import { ImageBackground } from 'react-native';"],
+      node.importComponent,
+    ),
+    renderComponent: (props, children) => [
       `<ImageBackground source={require('${exportImagesCodePrefix}/${fileName}')} ${rip(
         {
           resizeMode: resizeModes[scaleMode],
@@ -72,11 +75,11 @@ export default async function middleware({ node, nodeJson, context }) {
         0,
         `background-${props.key}`,
       )}>`,
-      ...node.renderCode(
+      ...node.renderComponent(
         {
           ...props,
           style: {
-            ...get(props, 'style'),
+            ..._.get(props, 'style'),
             ...clearStylePosition(),
           },
         },

--- a/src/parser/middleware/react-native/background-linear-gradient.js
+++ b/src/parser/middleware/react-native/background-linear-gradient.js
@@ -1,4 +1,4 @@
-import get from 'lodash/get';
+import _ from 'lodash';
 
 import { rip, color } from '../../../utils';
 
@@ -28,12 +28,15 @@ export default function middleware({ node, nodeJson }) {
 
   return {
     ...node,
-    importCode: ["import LinearGradient from 'react-native-linear-gradient';"],
-    renderCode: (props, children) => [
+    importComponent: _.concat(
+      ["import LinearGradient from 'react-native-linear-gradient';"],
+      node.importComponent,
+    ),
+    renderComponent: (props, children) => [
       `<LinearGradient ${rip(
         {
           style: {
-            ...get(props, 'style'),
+            ..._.get(props, 'style'),
             opacity,
           },
           start,
@@ -44,7 +47,7 @@ export default function middleware({ node, nodeJson }) {
         0,
         `gradient-background-${props.key}`,
       )}>`,
-      ...node.renderCode(props, children),
+      ...node.renderComponent(props, children),
       '</LinearGradient>',
     ],
   };

--- a/src/parser/middleware/react-native/export-to-component.js
+++ b/src/parser/middleware/react-native/export-to-component.js
@@ -4,7 +4,6 @@ import {
   copyStylePosition,
   copyStyleSize,
   clearStylePosition,
-  clearStyleSize,
 } from '../../../utils';
 
 export default async function middleware({
@@ -71,7 +70,6 @@ export default async function middleware({
       style: {
         ...props.style,
         ...clearStylePosition(),
-        ...clearStyleSize(),
         'last:prop': '...props.style',
       },
       'first:prop': '{...props}',

--- a/src/parser/middleware/react-native/index.js
+++ b/src/parser/middleware/react-native/index.js
@@ -1,17 +1,18 @@
 import nodeType from './node-type';
 import extNodeType from './ext-node-type';
-import layoutAndSize from './layout-and-size';
-
-import border from './border';
-import opacity from './opacity';
-import clipsContent from './clips-content';
 
 import backgroundSolid from './background-solid';
 import backgroundImage from './background-image';
 import backgroundLinearGradient from './background-linear-gradient';
 
+import border from './border';
+import opacity from './opacity';
+import clipsContent from './clips-content';
+
 import textStyles from './text-styles';
 
+import layoutAndSize from './layout-and-size';
+import stretch from './stretch';
 import exportAsImageOrSVG from './export-as-image-or-svg';
 import exportToComponent from './export-to-component';
 
@@ -26,6 +27,7 @@ const middlewares = [
   clipsContent,
   textStyles,
   layoutAndSize,
+  stretch,
   exportAsImageOrSVG,
   exportToComponent,
 ];

--- a/src/parser/middleware/react-native/node-type.js
+++ b/src/parser/middleware/react-native/node-type.js
@@ -8,56 +8,56 @@ export default function middleware({ node, nodeJson }) {
   switch (type) {
     case 'FRAME':
       // res.props = { ...node.props, style: { flex: 1 } };
-      res.importCode = ["import { View } from 'react-native';"];
-      res.renderCode = (props, children) => [
+      res.importComponent = ["import { View } from 'react-native';"];
+      res.renderComponent = (props, children) => [
         `<View ${rip(props, 0, `frame-${props.key}`)}>`,
         ...rc(children),
         '</View>',
       ];
       break;
     case 'GROUP':
-      res.importCode = ["import { View } from 'react-native';"];
-      res.renderCode = (props, children) => [
+      res.importComponent = ["import { View } from 'react-native';"];
+      res.renderComponent = (props, children) => [
         `<View ${rip(props, 0, `group-${props.key}`)}>`,
         ...rc(children),
         '</View>',
       ];
       break;
     case 'VECTOR':
-      res.importCode = ["import { View } from 'react-native';"];
-      res.renderCode = (props, children) => [
+      res.importComponent = ["import { View } from 'react-native';"];
+      res.renderComponent = (props, children) => [
         `<View ${rip(props, 0, `vector-${props.key}`)}>`,
         ...rc(children),
         '</View>',
       ];
       break;
     case 'RECTANGLE':
-      res.importCode = ["import { View } from 'react-native';"];
-      res.renderCode = (props, children) => [
+      res.importComponent = ["import { View } from 'react-native';"];
+      res.renderComponent = (props, children) => [
         `<View ${rip(props, 0, `rectangle-${props.key}`)}>`,
         ...rc(children),
         '</View>',
       ];
       break;
     case 'TEXT':
-      res.importCode = ["import { Text } from 'react-native';"];
-      res.renderCode = props => [
+      res.importComponent = ["import { Text } from 'react-native';"];
+      res.renderComponent = props => [
         `<Text ${rip(props, 0, `text-${props.key}`)}>${sanitizeText(
           nodeJson.characters,
         )}</Text>`,
       ];
       break;
     case 'COMPONENT':
-      res.importCode = ["import { View } from 'react-native';"];
-      res.renderCode = (props, children) => [
+      res.importComponent = ["import { View } from 'react-native';"];
+      res.renderComponent = (props, children) => [
         `<View ${rip(props, 0, `component-${props.key}`)}>`,
         ...rc(children),
         '</View>',
       ];
       break;
     case 'INSTANCE':
-      res.importCode = ["import { View } from 'react-native';"];
-      res.renderCode = (props, children) => [
+      res.importComponent = ["import { View } from 'react-native';"];
+      res.renderComponent = (props, children) => [
         `<View ${rip(props, 0, `instance-${props.key}`)}>`,
         ...rc(children),
         '</View>',

--- a/src/parser/middleware/react-native/stretch.js
+++ b/src/parser/middleware/react-native/stretch.js
@@ -1,0 +1,42 @@
+import get from 'lodash/get';
+
+import { clearStylePosition, clearStyleSize } from '../../../utils';
+
+export default function middleware({ node, context }) {
+  const { id } = node;
+  const { settingsJson } = context;
+
+  const {
+    // we need it mostly for parent (screen) components to occupy all the available space
+    fullWidth = false,
+    fullHeight = false,
+  } = settingsJson[id] || {};
+
+  if (!fullWidth && !fullHeight) {
+    return node;
+  }
+
+  if (fullWidth && fullHeight) {
+    return {
+      ...node,
+      props: {
+        style: {
+          ...node.props.style,
+          ...clearStylePosition(),
+          ...clearStyleSize(),
+          flex: 1,
+        },
+      },
+    };
+  }
+
+  return {
+    ...node,
+    props: {
+      style: {
+        ...node.props.style,
+        ...(fullWidth ? { width: '100%' } : { height: '100%' }),
+      },
+    },
+  };
+}

--- a/src/parser/parse-node.js
+++ b/src/parser/parse-node.js
@@ -44,9 +44,6 @@ export default async function parseNode({
   }
 
   const {
-    // should we add `flex: 1` to the component style
-    // we need it for parent (screen) components to occupy all the available space
-    stretch = false,
     // don't export component completely
     dontExport = false,
     // parse component but skip its children
@@ -58,14 +55,12 @@ export default async function parseNode({
     // hoc
     hoc,
     // extend by an existing component
-    extends: extend,
+    extend,
   } = settingsJson[id] || {};
 
   if (dontExport) {
     return null;
   }
-
-  const { mode } = extend || {};
 
   let node = null;
   // if parentNode is null then we are at the frame level or
@@ -80,9 +75,11 @@ export default async function parseNode({
       children: null,
       props: { key: id },
       hoc,
-      extends: extend,
+      extend,
     };
   }
+
+  const { mode } = extend || {};
 
   let noChildren =
     skipChildren ||
@@ -140,18 +137,6 @@ export default async function parseNode({
         }),
       node,
     );
-
-    if (stretch) {
-      node.props = {
-        ...node.props,
-        style: {
-          ...node.props.style,
-          ...clearStylePosition(),
-          ...clearStyleSize(),
-          flex: 1,
-        },
-      };
-    }
   }
 
   return node;

--- a/src/utils.js
+++ b/src/utils.js
@@ -186,9 +186,12 @@ export const rip0 = (props, level = 0) => {
         .filter(key => !_.isNil(props[key]))
         .sort((a, b) => {
           if (a === 'first:prop') return -1;
-          if (a === 'last:prop') return 1;
+          if (b === 'first:prop') return 1;
 
-          return a.localeCompare(b);
+          if (a === 'last:prop') return 1;
+          if (b === 'last:prop') return -1;
+
+          return 0;
         })
         .map(key => {
           if (key === 'first:prop' || key === 'last:prop') {
@@ -201,12 +204,16 @@ export const rip0 = (props, level = 0) => {
         })
         .join(', ')}}`;
     }
+
     return `${_.keys(props)
       .sort((a, b) => {
         if (a === 'first:prop') return -1;
-        if (a === 'last:prop') return 1;
+        if (b === 'first:prop') return 1;
 
-        return a.localeCompare(b);
+        if (a === 'last:prop') return 1;
+        if (b === 'last:prop') return -1;
+
+        return 0;
       })
       .map(key => {
         const value = props[key];
@@ -245,7 +252,9 @@ export const rip = (props, level = 0, name = null) => {
 
 export const rc = children =>
   _.flatMap(children, child => {
-    const { renderCode, props, children: ch } = child;
+    const { renderDecorator, renderComponent, props, children: ch } = child;
+    const renderCode = renderDecorator || renderComponent;
+
     return renderCode(props, ch, child);
   });
 
@@ -278,24 +287,12 @@ export function getInstanceNode(
     .filter(t => !!t)
     .join('/');
 
-  if (node.renderInstance) {
-    return {
-      ...node,
-      props,
-      importCode: [`import ${componentName} from '${filePath}';`],
-      // eslint-disable-next-line no-shadow
-      renderInstance: props => [
-        `<${componentName} ${rip(props, 0, `instance-${props.key}`)} />`,
-      ],
-    };
-  }
-
   return {
     ...node,
     props,
-    importCode: [`import ${componentName} from '${filePath}';`],
+    importComponent: [`import ${componentName} from '${filePath}';`],
     // eslint-disable-next-line no-shadow
-    renderCode: props => [
+    renderComponent: props => [
       `<${componentName} ${rip(props, 0, `instance-${props.key}`)} />`,
     ],
   };


### PR DESCRIPTION
… that fix following issue:

Let's assume that we have a node that we decided to extract to a component and this node should be center aligned regardless its parent.
The problem was that in layout-and-size middleware we wrap this node inside a View. View will take all available space and node will position at center of the View.
All this logic will be stored inside `renderCode` function.

Next, inside export-to-component middleware we will decide that component should be extracted to a component, so we will create a file and render code using `renderCode` function,
but this function also contains render of View and center positioned element, that should not be part of the new component. We would like to extract to a component only node,
and wrap by View only instance of that component, but we can't because we have only one function 'renderCode'.

To avoid this I decided to separate node rendering into two parts:
`importComponent` and `renderComponent` will take care to rendering component only (everything that should be extracted inside a component)
`importDecorator` and `renderDecorator` will take care to rendering everything that wrap the component (layout or 'wrapWith' extend)